### PR TITLE
Copy timezones from base to scratch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ RUN mkdir /user && \
     echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \
     echo 'nobody:x:65534:' > /user/group
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates tzdata
 
 FROM scratch AS final
 
 COPY --from=base /user/group /user/passwd /etc/
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base /usr/share/zoneinfo/ /usr/share/zoneinfo
 
 USER nobody:nobody

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ITCH
 
-### The itch you don't need to scratch
+## The itch you don't need to scratch
 
 Itch is a prebuilt docker image built `FROM SCRATCH` that contains ca-certificates from alpine and a user `nobody`.
 
@@ -23,10 +23,13 @@ ENTRYPOINT ["/app"]
 ```
 
 See the example above in action
+
 - **examples/helloworld/** says Hello World and tells which user is running.
 - **examples/httpget/** Shows how ITCH differs from SCRATCH when requesting data over HTTPS.
+- **examples/timezone/** Shows how ITCH differs from SCRATCH when loading location zones.
 
 Test each of the examples with
+
 ```sh
 $ make build # builds individual scratch and itch images
 $ make run   # executes SCRATCH and ITCH versions to compare behaviour

--- a/examples/timezone/Dockerfile
+++ b/examples/timezone/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.11-alpine as builder
+WORKDIR /go/src/app
+COPY main.go main.go
+RUN CGO_ENABLED=0 go build \
+      -ldflags='-w -s' \
+      -o /app main.go
+
+# Copy binary to itch
+FROM jarlefosen/itch
+COPY --from=builder /app /app
+ENTRYPOINT ["/app"]

--- a/examples/timezone/Dockerfile.scratch
+++ b/examples/timezone/Dockerfile.scratch
@@ -1,0 +1,11 @@
+FROM golang:1.11-alpine as builder
+WORKDIR /go/src/app
+COPY main.go main.go
+RUN CGO_ENABLED=0 go build \
+      -ldflags="-w -s" \
+      -o /app main.go
+
+# Copy binary to itch
+FROM scratch
+COPY --from=builder /app /app
+ENTRYPOINT ["/app"]

--- a/examples/timezone/Makefile
+++ b/examples/timezone/Makefile
@@ -1,0 +1,28 @@
+.PHONY: all build-scratch build-itch build clean run-scratch run-itch run
+
+IMG_ITCH := example-timezone:itch
+IMG_SCRATCH := example-timezone:scratch
+
+all: build run
+
+build-scratch:
+	docker build -t $(IMG_SCRATCH) -f Dockerfile.scratch .
+
+build-itch:
+	docker build -t $(IMG_ITCH) -f Dockerfile .
+
+build: build-itch build-scratch
+
+clean:
+	docker rmi $(IMG_SCRATCH)
+	docker rmi $(IMG_ITCH)
+
+run-scratch:
+	@echo Running $(IMG_SCRATCH)
+	@docker run --rm $(IMG_SCRATCH)
+
+run-itch:
+	@echo Running $(IMG_ITCH)
+	@docker run --rm $(IMG_ITCH)
+
+run: run-scratch run-itch

--- a/examples/timezone/main.go
+++ b/examples/timezone/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	location := "America/New_York"
+	loc, err := time.LoadLocation(location)
+	if err != nil {
+		fmt.Printf("[FAIL] load location %q from tz data: %s\n", location, err)
+	} else {
+		fmt.Printf("[ OK ] loaded location: %s\n", loc.String())
+	}
+}


### PR DESCRIPTION
This adds `tzdata` to the base build and copies the time zone files to scratch. An example is included.